### PR TITLE
Fixed translation broadcasting in BodyFitter.fit_with_known_shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ vertices = torch.rand((batch_size, 6890, 3)).cuda()
 joints = torch.rand((batch_size, 24, 3)).cuda()
 
 # Do the fitting!
-fit_res = fitter.fit(vertices, joints, n_iter=3, beta_regularizer=1)
+fit_res = fitter.fit(vertices, joints, num_iter=3, beta_regularizer=1)
 fit_res['pose_rotvecs'], fit_res['shape_betas'], fit_res['trans']
 ```
 

--- a/src/smplfitter/pt/bodyfitter.py
+++ b/src/smplfitter/pt/bodyfitter.py
@@ -560,8 +560,8 @@ class BodyFitter(nn.Module):
                 glob_rotmats = self._fit_global_rotations_dependent(
                     target_vertices,
                     target_joints,
-                    ref_verts + ref_trans,
-                    ref_joints + ref_trans,
+                    ref_verts + ref_trans.unsqueeze(-2),
+                    ref_joints + ref_trans.unsqueeze(-2),
                     vertex_weights,
                     joint_weights,
                     glob_rotmats,


### PR DESCRIPTION
Dimensions of `ref_trans` in lines 563-564 are (-1,3), while `ref_verts` are (-1,6890,3) and `ref_joints` are (-1,24,3). Without unsqueeze (similar to lines 549-550) the code fails to broadcast the dimensions.